### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,3 @@
-# LICENSE
-
 MIT License
 
 Copyright (c) 2025 Dylan Gregori Singer (symmetricalboy)


### PR DESCRIPTION
LICENCE/LICENSE files don't need a markdown heading tag.